### PR TITLE
Update name and link to motioneye project

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Curated list of projects with raspberry pi on whole www (!only github)
 ## security
  * [CircClean](https://www.circl.lu/projects/CIRCLean/) clean your usbkey
  * [Internet Enabled DSC Home Security System](http://www.instructables.com/id/Ethernet-Enabled-DSC-Home-Security-System/?ALLSTEPS)
- * [MotionPie](https://github.com/ccrisan/motionpie) - [site](http://pimylifeup.com/raspberry-pi-security-camera/)
+ * [MotionEyeOS](https://github.com/ccrisan/motioneyeos) video surveillance system
  * [Raspberry PI-TIMOLO: PI-TImelapse, MOtion, LOwLight](https://github.com/pageauc/pi-timolo)
  * [PI-TIMOLO Detector](https://github.com/af001/pi-detector)
  * [P4wnP1](https://github.com/mame82/P4wnP1) P4wnP1 is a highly customizable USB attack platform, based on a low cost Raspberry Pi Zero or Raspberry Pi Zero W.


### PR DESCRIPTION
The motionpie project, as noted in the README of the [project](https://github.com/ccrisan/motionpie) as been renamed and lives now at https://github.com/ccrisan/motioneyeos.
Name and link has been updated.