### PR TITLE
Add PiSpot Show and PiSpot Watch projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Curated list of projects with raspberry pi on whole www (!only github)
 
 ## gadget
  * [EXT] [harry potter newspaper](https://www.hackster.io/whitney-knitter/harry-potter-newspaper-powered-by-raspberry-pi-zero-3927f8)
+ * [PiSpot Show](https://github.com/GeiserX/PiSpot-Show) - Turn any HDMI display into a self-updating Wi-Fi voucher kiosk with live weather, powered by Raspberry Pi
 
 ## home stuff
  * [EXT] [ScrapPi - Upcycled Media Hub](http://www.instructables.com/id/ScrapPi-Upcycled-Media-Hub/?ALLSTEPS)
@@ -197,6 +198,7 @@ where to discover new articles, tools, libraries etc related to raspberry pi
  * [EXT] [Swiss Raspberry Pi Users Club](http://swissraspberry.ch/)
 
 ## wearable
+ * [PiSpot Watch](https://github.com/GeiserX/PiSpot-Watch) - Wrist-wearable e-ink smartwatch that generates Wi-Fi voucher codes on demand via Raspberry Pi Zero
  * [Raspberry Pi Timelapse Camera](https://github.com/Manoj-nathwani/raspberry-pi-timelapse-camera)
  
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Curated list of projects with raspberry pi on whole www (!only github)
 
 ## gadget
  * [EXT] [harry potter newspaper](https://www.hackster.io/whitney-knitter/harry-potter-newspaper-powered-by-raspberry-pi-zero-3927f8)
- * [PiSpot Show](https://github.com/GeiserX/PiSpot-Show) - Turn any HDMI display into a self-updating Wi-Fi voucher kiosk with live weather, powered by Raspberry Pi
+ * [PiSpot Show](https://github.com/GeiserX/PiSpot-Show) - Turn any HDMI display into a self-updating Wi-Fi voucher kiosk with live weather, powered by Raspberry Pi.
 
 ## home stuff
  * [EXT] [ScrapPi - Upcycled Media Hub](http://www.instructables.com/id/ScrapPi-Upcycled-Media-Hub/?ALLSTEPS)
@@ -198,7 +198,7 @@ where to discover new articles, tools, libraries etc related to raspberry pi
  * [EXT] [Swiss Raspberry Pi Users Club](http://swissraspberry.ch/)
 
 ## wearable
- * [PiSpot Watch](https://github.com/GeiserX/PiSpot-Watch) - Wrist-wearable e-ink smartwatch that generates Wi-Fi voucher codes on demand via Raspberry Pi Zero
+ * [PiSpot Watch](https://github.com/GeiserX/PiSpot-Watch) - Wrist-wearable e-ink smartwatch that generates Wi-Fi voucher codes on demand via Raspberry Pi Zero.
  * [Raspberry Pi Timelapse Camera](https://github.com/Manoj-nathwani/raspberry-pi-timelapse-camera)
  
 


### PR DESCRIPTION
## Summary

- **PiSpot Show** added to the **gadget** section: an HDMI kiosk display that generates hourly Wi-Fi voucher codes with live weather overlay, powered by Raspberry Pi.
- **PiSpot Watch** added to the **wearable** section: a wrist-wearable e-ink smartwatch built on Raspberry Pi Zero that generates Wi-Fi voucher codes on demand.

Both are open-source (GPL-3.0) Raspberry Pi projects, part of the [PiSpot ecosystem](https://github.com/GeiserX/PiSpot-Show), originally developed in 2018 for hotel and venue Wi-Fi management.
